### PR TITLE
Update .gitignore to partially fix node_modules disaster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+node_modules/
 *.sqlite
 json.sqlite
 *.sqlite


### PR DESCRIPTION
More than slightly unbelievable how .gitignore does not contain node_modules. It's almost surely a nightmare idea to commit node_modules into your package, and force people to download that. Please be nice to the open source community and resolve.

Fixes #1 